### PR TITLE
Add agents subnet

### DIFF
--- a/infra-as-code/bicep/network.bicep
+++ b/infra-as-code/bicep/network.bicep
@@ -18,6 +18,7 @@ var vnetAddressPrefix = '10.0.0.0/16'
 var appGatewaySubnetPrefix = '10.0.1.0/24'
 var appServicesSubnetPrefix = '10.0.0.0/24'
 var privateEndpointsSubnetPrefix = '10.0.2.0/27'
+var agentsSubnetPrefix = '10.0.2.32/27'
 
 //Temp disable DDoS protection
 var enableDdosProtection = !developmentEnvironment
@@ -83,7 +84,16 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-11-01' = {
             id: privateEndpointsSubnetNsg.id
           }
         }
-
+      }
+      {
+        // Build agents subnet
+        name: 'snet-agents'
+        properties: {
+          addressPrefix: agentsSubnetPrefix
+          networkSecurityGroup: {
+            id: agentsSubnetNsg.id
+          }
+        }
       }
     ]
   }
@@ -99,6 +109,10 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-11-01' = {
   resource privateEnpointsSubnet 'subnets' existing = {
     name: 'snet-privateEndpoints'
   }
+
+  resource agentsSubnet 'subnets' existing = {
+    name: 'snet-agents'
+  }  
 }
 
 //App Gateway subnet NSG
@@ -222,6 +236,13 @@ resource appServiceSubnetNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01
 //Private endpoints subnets NSG
 resource privateEndpointsSubnetNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
   name: 'nsg-privateEndpointsSubnet'
+  location: location
+  properties: {}
+}
+
+//Build agents subnets NSG
+resource agentsSubnetNsg 'Microsoft.Network/networkSecurityGroups@2022-11-01' = {
+  name: 'nsg-agentsSubnet'
   location: location
   properties: {}
 }


### PR DESCRIPTION
## Purpose

Added a new subnet to network.bicep to correspond to the build agents subnet represented in the reference architecture article. The subnet will be initially empty but serves as a placeholder to quickly implement a build agent solution (for example: deploying an ACI resource) that would be able to publish the solution files directly to storage. Avoiding this way the need to manually update the storage firewall settings.

```
## Does this introduce a breaking change?
[ ] Yes
[x ] No
```
## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->