### PR TITLE
Use keyvaultDns suffix property to create the SecretUri

### DIFF
--- a/infra-as-code/bicep/webapp.bicep
+++ b/infra-as-code/bicep/webapp.bicep
@@ -156,7 +156,7 @@ resource appsettings 'Microsoft.Web/sites/config@2022-09-01' = {
   properties: {
     WEBSITE_RUN_FROM_PACKAGE: packageLocation
     WEBSITE_RUN_FROM_PACKAGE_BLOB_MI_RESOURCE_ID: appServiceManagedIdentity.id
-    adWorksConnString: '@Microsoft.KeyVault(SecretUri=https://${keyVault.name}.vault.azure.net/secrets/adWorksConnString)'
+    adWorksConnString: '@Microsoft.KeyVault(SecretUri=https://${keyVault.name}${environment().suffixes.keyvaultDns}/secrets/adWorksConnString)'
     APPINSIGHTS_INSTRUMENTATIONKEY: appInsights.properties.InstrumentationKey
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsights.properties.ConnectionString
     ApplicationInsightsAgent_EXTENSION_VERSION: '~2'


### PR DESCRIPTION
## Purpose
This change makes sure that the key vault reference also works on non-global Azure clouds (i.e. sovereign clouds). 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
## How to Test
* Deploy the infrastructure as described in the `README`. 
* List the app settings from the web app
```
BASE_NAME=<base-resource-name>
RESOURCE_GROUP=<resource-group-name>

az webapp config appsettings list --name app-$BASE_NAME --resource-group $RESOURCE_GROUP
```

## What to Check
Verify that the `adWorksConnString` app setting is referencing `https://<keyvault-name>.vault.azure.net/secrets/adWorksConnString` when deployed to a global Azure environment.