### PR TITLE
patch (infra): [diagnostic settings] remove retention

### DIFF
--- a/infra-as-code/bicep/gateway.bicep
+++ b/infra-as-code/bicep/gateway.bicep
@@ -289,10 +289,6 @@ resource appGatewayDiagSettings 'Microsoft.Insights/diagnosticSettings@2021-05-0
       {
         categoryGroup: 'allLogs'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [

--- a/infra-as-code/bicep/webapp.bicep
+++ b/infra-as-code/bicep/webapp.bicep
@@ -229,10 +229,6 @@ resource appServicePlanDiagSettings 'Microsoft.Insights/diagnosticSettings@2021-
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }
@@ -249,38 +245,22 @@ resource webAppDiagSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
         category: 'AppServiceHTTPLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceConsoleLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
       {
         category: 'AppServiceAppLogs'
         categoryGroup: null
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
     metrics: [
       {
         category: 'AllMetrics'
         enabled: true
-        retentionPolicy: {
-          days: 7
-          enabled: true
-        }
       }
     ]
   }


### PR DESCRIPTION
## Purpose
It is no longer supported the storage retention for diagnostic settings, so they are being removed from the example.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Follow the readme instructions

## What to Check
You were able to deploy the example without errors from control plane.

## Other Information
consider migrating from diagnostic settings storage retention to Azure Storage lifecycle management.